### PR TITLE
feat: add actionsByWeekday chart

### DIFF
--- a/src/components/space/charts-layout/ChartsArea.js
+++ b/src/components/space/charts-layout/ChartsArea.js
@@ -6,6 +6,7 @@ import ActionsByDayChart from '../charts/ActionsByDayChart';
 import ActionsByTimeOfDayChart from '../charts/ActionsByTimeOfDayChart';
 import ActionsByUserChart from '../charts/ActionsByUserChart';
 import ActionsByVerbChart from '../charts/ActionsByVerbChart';
+import ActionsByWeekdayChart from '../charts/ActionsByWeekdayChart';
 import ActionsMap from '../charts/ActionsMap';
 import ItemsByActionChart from '../charts/ItemsByActionChart';
 import ItemsByUserChart from '../charts/ItemsByUserChart';
@@ -36,6 +37,9 @@ const ChartsArea = () => (
     </Grid>
     <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
       <ItemsByActionChart />
+    </Grid>
+    <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
+      <ActionsByWeekdayChart />
     </Grid>
   </Grid>
 );

--- a/src/components/space/charts-layout/ChartsArea.js
+++ b/src/components/space/charts-layout/ChartsArea.js
@@ -21,6 +21,9 @@ const ChartsArea = () => (
       <ActionsByTimeOfDayChart />
     </Grid>
     <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+      <ActionsByWeekdayChart />
+    </Grid>
+    <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
       <ActionsMap />
     </Grid>
     <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
@@ -37,9 +40,6 @@ const ChartsArea = () => (
     </Grid>
     <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
       <ItemsByActionChart />
-    </Grid>
-    <Grid item xs={12} sm={12} md={12} lg={12} xl={12}>
-      <ActionsByWeekdayChart />
     </Grid>
   </Grid>
 );

--- a/src/components/space/charts/ActionsByWeekdayChart.js
+++ b/src/components/space/charts/ActionsByWeekdayChart.js
@@ -1,0 +1,63 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+
+import React, { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  findYAxisMax,
+  formatActionsByWeekday,
+  getActionsByWeekday,
+} from '../../../utils/api';
+import { filterActions } from '../../../utils/array';
+import ChartContainer from '../../common/ChartContainer';
+import ChartTitle from '../../common/ChartTitle';
+import { DataContext } from '../../context/DataProvider';
+import EmptyChart from './EmptyChart';
+
+const ActionsByWeekdayChart = () => {
+  const { t } = useTranslation();
+  const { actions, allMembers, selectedUsers, selectedActions } =
+    useContext(DataContext);
+
+  // ActionsByWeekday is the object passed, after formatting, to the BarChart component below
+
+  // if you remove all names in the react-select dropdown, selectedUsers becomes null
+  // if no users are selected (i.e. selectedUsers.size === 0), show all actions
+  // if all users are selected (i.e. selectedUsers.size === allMembers.size), also show all actions
+  // third condition above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+  // therefore, to avoid confusion: when all users are selected, show all actions
+  let ActionsByWeekday = [];
+  if (actions?.size) {
+    ActionsByWeekday = filterActions({
+      selectedUsers,
+      selectedActions,
+      actions,
+      allMembersLength: allMembers.size,
+      chartFunction: getActionsByWeekday,
+    });
+  }
+  const yAxisMax = findYAxisMax(ActionsByWeekday);
+  const formattedActionsByWeekday = formatActionsByWeekday(ActionsByWeekday);
+
+  const title = 'Actions By Weekday';
+  // if selected user(s) have no actions, render component with message that there are no actions
+  if (formattedActionsByWeekday.every((weekday) => weekday.count === 0)) {
+    return <EmptyChart selectedUsers={selectedUsers} chartTitle={t(title)} />;
+  }
+
+  return (
+    <>
+      <ChartTitle>{t('Actions By Weekday')}</ChartTitle>
+      <ChartContainer>
+        <BarChart data={formattedActionsByWeekday}>
+          <CartesianGrid strokeDasharray="2" />
+          <XAxis interval={0} dataKey="day" tick={{ fontSize: 14 }} />
+          <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
+          <Bar dataKey="count" name={t('Count')} fill="#8884d8" />
+        </BarChart>
+      </ChartContainer>
+    </>
+  );
+};
+export default ActionsByWeekdayChart;

--- a/src/components/space/charts/ActionsByWeekdayChart.js
+++ b/src/components/space/charts/ActionsByWeekdayChart.js
@@ -27,9 +27,9 @@ const ActionsByWeekdayChart = () => {
   // third condition above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
   // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
   // therefore, to avoid confusion: when all users are selected, show all actions
-  let ActionsByWeekday = [];
+  let actionsByWeekday = [];
   if (actions?.size) {
-    ActionsByWeekday = filterActions({
+    actionsByWeekday = filterActions({
       selectedUsers,
       selectedActions,
       actions,
@@ -37,8 +37,8 @@ const ActionsByWeekdayChart = () => {
       chartFunction: getActionsByWeekday,
     });
   }
-  const yAxisMax = findYAxisMax(ActionsByWeekday);
-  const formattedActionsByWeekday = formatActionsByWeekday(ActionsByWeekday);
+  const yAxisMax = findYAxisMax(actionsByWeekday);
+  const formattedActionsByWeekday = formatActionsByWeekday(actionsByWeekday);
 
   const title = 'Actions By Weekday';
   // if selected user(s) have no actions, render component with message that there are no actions

--- a/src/components/space/charts/ActionsByWeekdayChart.tsx
+++ b/src/components/space/charts/ActionsByWeekdayChart.tsx
@@ -1,6 +1,6 @@
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -14,7 +14,7 @@ import ChartTitle from '../../common/ChartTitle';
 import { DataContext } from '../../context/DataProvider';
 import EmptyChart from './EmptyChart';
 
-const ActionsByWeekdayChart = () => {
+const ActionsByWeekdayChart = (): JSX.Element => {
   const { t } = useTranslation();
   const { actions, allMembers, selectedUsers, selectedActions } =
     useContext(DataContext);
@@ -43,7 +43,7 @@ const ActionsByWeekdayChart = () => {
   const title = 'Actions By Weekday';
   // if selected user(s) have no actions, render component with message that there are no actions
   if (formattedActionsByWeekday.every((weekday) => weekday.count === 0)) {
-    return <EmptyChart selectedUsers={selectedUsers} chartTitle={t(title)} />;
+    return <EmptyChart chartTitle={t(title)} />;
   }
 
   return (
@@ -54,6 +54,7 @@ const ActionsByWeekdayChart = () => {
           <CartesianGrid strokeDasharray="2" />
           <XAxis interval={0} dataKey="day" tick={{ fontSize: 14 }} />
           <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
+          <Tooltip />
           <Bar dataKey="count" name={t('Count')} fill="#8884d8" />
         </BarChart>
       </ChartContainer>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -123,10 +123,10 @@ const getActionWeekday = (action) => {
 
 // Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
 export const getActionsByWeekday = (actions) => {
-  const defaultActionsByWeekday = { ...Array(7).fill(0) };
-  const actionsByWeekday = actions?.countBy(getActionWeekday).toJS();
-  Object.assign(defaultActionsByWeekday, actionsByWeekday);
-  return defaultActionsByWeekday;
+  const actionsByWeekday = { ...Array(7).fill(0) };
+  const updatedActionsByWeekday = actions?.countBy(getActionWeekday).toJS();
+  Object.assign(actionsByWeekday, updatedActionsByWeekday);
+  return actionsByWeekday;
 };
 
 // Takes object with {key: value} pairs of {weekday: #-of-actions}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -123,13 +123,12 @@ const getActionWeekday = (action) => {
 
 // Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
 export const getActionsByWeekday = (actions) => {
-  const actionsByWeekdayMap = new Map(actions?.countBy(getActionWeekday));
+  const actionsByWeekday = actions?.countBy(getActionWeekday).toJS();
   for (let weekday = 0; weekday < 7; weekday += 1) {
-    if (!actionsByWeekdayMap.has(weekday)) {
-      actionsByWeekdayMap.set(weekday, 0);
+    if (!(weekday in actionsByWeekday)) {
+      actionsByWeekday[weekday] = 0;
     }
   }
-  const actionsByWeekday = Object.fromEntries(actionsByWeekdayMap);
   return actionsByWeekday;
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -112,6 +112,57 @@ export const formatActionsByTimeOfDay = (actionsByTimeOfDayObject) => {
   }));
 };
 
+// helper function used in getActionsByWeekday below
+const getActionWeekday = (action) => {
+  const dateKey = 'createdAt';
+  // createdAt should have the format "2020-12-31T23:59:59.999Z"
+  const date = new Date(action[dateKey]);
+  const weekday = date.getDay();
+  return weekday;
+};
+
+// Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
+export const getActionsByWeekday = (actions) => {
+  const actionsByWeekday = {
+    SUNDAY: 0,
+    MONDAY: 0,
+    TUESDAY: 0,
+    WEDNESDAY: 0,
+    THURSDAY: 0,
+    FRIDAY: 0,
+    SATURDAY: 0,
+  };
+  const weekdayEnum = {
+    0: 'SUNDAY',
+    1: 'MONDAY',
+    2: 'TUESDAY',
+    3: 'WEDNESDAY',
+    4: 'THURSDAY',
+    5: 'FRIDAY',
+    6: 'SATURDAY',
+  };
+  actions?.forEach((action) => {
+    const actionWeekday = getActionWeekday(action);
+    if (actionWeekday >= 1 && actionWeekday <= 7) {
+      actionsByWeekday[weekdayEnum[actionWeekday]] += 1;
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`actionWeekday ${actionWeekday} is undefined`);
+    }
+  });
+  return actionsByWeekday;
+};
+
+// Takes object with {key: value} pairs of {weekday: #-of-actions}
+// returns an array in Recharts.js format
+export const formatActionsByWeekday = (actionsByWeekdayObject) => {
+  const actionsByWeekdayArray = Object.entries(actionsByWeekdayObject);
+  return actionsByWeekdayArray.map((entry) => ({
+    day: entry[0],
+    count: entry[1],
+  }));
+};
+
 // Takes array of action objects and returns an object with {key: value} pairs of {verb: %-of-actions}
 export const getActionsByVerb = (actions) => {
   const totalActions = actions.size;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -124,27 +124,18 @@ const getActionWeekday = (action) => {
 // Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
 export const getActionsByWeekday = (actions) => {
   const actionsByWeekday = {
-    SUNDAY: 0,
-    MONDAY: 0,
-    TUESDAY: 0,
-    WEDNESDAY: 0,
-    THURSDAY: 0,
-    FRIDAY: 0,
-    SATURDAY: 0,
-  };
-  const weekdayEnum = {
-    0: 'SUNDAY',
-    1: 'MONDAY',
-    2: 'TUESDAY',
-    3: 'WEDNESDAY',
-    4: 'THURSDAY',
-    5: 'FRIDAY',
-    6: 'SATURDAY',
+    0: 0,
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 0,
+    5: 0,
+    6: 0,
   };
   actions?.forEach((action) => {
     const actionWeekday = getActionWeekday(action);
     if (actionWeekday >= 1 && actionWeekday <= 7) {
-      actionsByWeekday[weekdayEnum[actionWeekday]] += 1;
+      actionsByWeekday[actionWeekday] += 1;
     } else {
       // eslint-disable-next-line no-console
       console.error(`actionWeekday ${actionWeekday} is undefined`);
@@ -156,10 +147,19 @@ export const getActionsByWeekday = (actions) => {
 // Takes object with {key: value} pairs of {weekday: #-of-actions}
 // returns an array in Recharts.js format
 export const formatActionsByWeekday = (actionsByWeekdayObject) => {
+  const weekdayEnum = {
+    0: 'Sunday',
+    1: 'Monday',
+    2: 'Tuesday',
+    3: 'Wednesday',
+    4: 'Thursday',
+    5: 'Friday',
+    6: 'Saturday',
+  };
   const actionsByWeekdayArray = Object.entries(actionsByWeekdayObject);
-  return actionsByWeekdayArray.map((entry) => ({
-    day: entry[0],
-    count: entry[1],
+  return actionsByWeekdayArray.map(([day, count]) => ({
+    day: weekdayEnum[day],
+    count,
   }));
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -123,24 +123,13 @@ const getActionWeekday = (action) => {
 
 // Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
 export const getActionsByWeekday = (actions) => {
-  const actionsByWeekday = {
-    0: 0,
-    1: 0,
-    2: 0,
-    3: 0,
-    4: 0,
-    5: 0,
-    6: 0,
-  };
-  actions?.forEach((action) => {
-    const actionWeekday = getActionWeekday(action);
-    if (actionWeekday >= 1 && actionWeekday <= 7) {
-      actionsByWeekday[actionWeekday] += 1;
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(`actionWeekday ${actionWeekday} is undefined`);
+  const actionsByWeekdayMap = new Map(actions?.countBy(getActionWeekday));
+  for (let weekday = 0; weekday < 7; weekday += 1) {
+    if (!actionsByWeekdayMap.has(weekday)) {
+      actionsByWeekdayMap.set(weekday, 0);
     }
-  });
+  }
+  const actionsByWeekday = Object.fromEntries(actionsByWeekdayMap);
   return actionsByWeekday;
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -123,13 +123,10 @@ const getActionWeekday = (action) => {
 
 // Takes array of action objects and returns an object with {key: value} pairs of {weekday: #-of-actions}
 export const getActionsByWeekday = (actions) => {
+  const defaultActionsByWeekday = { ...Array(7).fill(0) };
   const actionsByWeekday = actions?.countBy(getActionWeekday).toJS();
-  for (let weekday = 0; weekday < 7; weekday += 1) {
-    if (!(weekday in actionsByWeekday)) {
-      actionsByWeekday[weekday] = 0;
-    }
-  }
-  return actionsByWeekday;
+  Object.assign(defaultActionsByWeekday, actionsByWeekday);
+  return defaultActionsByWeekday;
 };
 
 // Takes object with {key: value} pairs of {weekday: #-of-actions}


### PR DESCRIPTION
This PR add actionsByWeekday chart. Most codes are taken from the actionsByTimeOfDay chart. The chart are shown in the following.

<img width="1336" alt="Screenshot 2023-03-13 at 10 42 36 AM" src="https://user-images.githubusercontent.com/13879502/224665073-39ab5a9f-7c1b-43bc-997d-4b1901ecb331.png">
