### PR TITLE
fix(style): remove default browser margins with CSSBaseline

### DIFF
--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -3,7 +3,7 @@ import { I18nextProvider } from 'react-i18next';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-import { ThemeProvider, styled } from '@mui/material';
+import { CssBaseline, ThemeProvider, styled } from '@mui/material';
 
 import { hasAcceptedCookies } from '@graasp/sdk';
 import { theme } from '@graasp/ui';
@@ -31,6 +31,7 @@ const CustomRoot = styled('div')({
 const Root = (): JSX.Element => (
   <QueryClientProvider client={queryClient}>
     <ThemeProvider theme={theme}>
+      <CssBaseline />
       <CustomRoot>
         <I18nextProvider i18n={i18nConfig}>
           <App />


### PR DESCRIPTION
There was a missing `CSSBaseline` which mean the useragent styles would be applied making the site look dumb.

Before:
<img width="460" alt="Screenshot 2023-09-29 at 13 02 08" src="https://github.com/graasp/graasp-analytics/assets/39373170/d3f48017-460f-4adc-92e2-1a34f43cbaca">

After:
<img width="452" alt="Screenshot 2023-09-29 at 13 02 55" src="https://github.com/graasp/graasp-analytics/assets/39373170/df9615cc-daed-4dc3-8200-c6f96986834b">
